### PR TITLE
Fix package.json to work on Windows properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Simple boilerplate for static website",
   "scripts": {
     "build:scss": "node-sass --output-style compressed -o dist/styles src/styles",
-    "watch:scss": "onchange -i -v 'src/styles/*.scss' -- npm run build:scss",
-    "lint:js": "eslint --fix src/js/*.js",
-    "watch:js": "onchange -i -v 'src/js/*.js' -- npm run lint:js",
-    "start": "browser-sync -s -f './index.html, dist/**/*, src/**/*'",
-    "watch:all": "parallelshell 'npm start' 'npm run watch:scss' 'npm run watch:js'"
+    "watch:scss": "onchange -i -v \"./src/styles/*.scss\" -- npm run build:scss",
+    "lint:js": "eslint --fix ./src/js/*.js",
+    "watch:js": "onchange -i -v \"./src/js/*.js\" -- npm run lint:js",
+    "start": "browser-sync -s -f \"./index.html, dist/**/*, src/**/*\"",
+    "watch:all": "parallelshell \"npm start\" \"npm run watch:scss\" \"npm run watch:js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I've replaced in package.json ' in comands with \" in comands so now commands work properly on Windows OS