### PR TITLE
Enable zooming

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Hello Roman Boilerplate</title>
   <script defer src="src/js/index.js"></script>


### PR DESCRIPTION
I've enabled zooming by changing `meta[name=viewport]` according to [warning in HTML 5.2](https://www.w3.org/TR/html52/document-metadata.html#example-8dc32ede) and [WCAG 2.1 requirements](https://www.w3.org/WAI/WCAG21/quickref/#resize-text).